### PR TITLE
Add edit functionality and context menu to prompts

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -729,6 +729,18 @@ function App() {
     }
   }, []);
 
+  const updatePrompt = useCallback(async (promptId, updates) => {
+    try {
+      const response = await promptsAPI.updatePrompt(promptId, updates);
+      const updated = response.data;
+      setPrompts(prev => prev.map(p => p.id === promptId ? { ...p, ...updated } : p));
+      toast.success("Prompt updated successfully.");
+    } catch (error) {
+      console.error('Failed to update prompt:', error);
+      toast.error("Failed to update prompt template.");
+    }
+  }, []);
+
   const renameSession = useCallback(async (sessionId, newTitle) => {
     try {
       await sessionsAPI.updateSession(sessionId, {
@@ -876,6 +888,7 @@ function App() {
             onNewPrompt={createPrompt}
             onUsePrompt={usePrompt}
             onDeletePrompt={deletePrompt}
+            onEditPrompt={updatePrompt}
             onOpenSettings={() => setIsSettingsOpen(true)}
             onLogout={handleLogout}
           />
@@ -897,6 +910,7 @@ function App() {
                 onNewPrompt={createPrompt}
                 onUsePrompt={usePrompt}
                 onDeletePrompt={deletePrompt}
+                onEditPrompt={updatePrompt}
                 onOpenSettings={() => setIsSettingsOpen(true)}
                 onLogout={handleLogout}
                 isMobileOverlay={true}

--- a/frontend/src/components/ContextMenu.jsx
+++ b/frontend/src/components/ContextMenu.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Edit3, Trash2, X } from 'lucide-react';
 
-const ContextMenu = ({ isVisible, position, onRename, onDelete, onClose, deleteLabel = "Delete" }) => {
+const ContextMenu = ({ isVisible, position, onRename, onDelete, onClose, deleteLabel = "Delete", renameLabel = "Rename" }) => {
   const menuRef = useRef(null);
 
   useEffect(() => {
@@ -46,7 +46,7 @@ const ContextMenu = ({ isVisible, position, onRename, onDelete, onClose, deleteL
         onClick={onRename}
       >
         <Edit3 className="h-4 w-4" />
-        Rename
+        {renameLabel}
       </button>
       <button
         className={`w-full px-3 py-2 text-sm text-left flex items-center gap-2 ${


### PR DESCRIPTION
Add prompt editing functionality to the sidebar, allowing users to modify saved prompts via an edit button and a right-click context menu.

---
<a href="https://cursor.com/background-agent?bcId=bc-1a19e36a-3cd3-4fc1-89e8-7ac371e3afbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1a19e36a-3cd3-4fc1-89e8-7ac371e3afbb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

